### PR TITLE
Refactoring Template/Context

### DIFF
--- a/Sources/Liquid/BlockBody.swift
+++ b/Sources/Liquid/BlockBody.swift
@@ -30,7 +30,7 @@ class BlockBody {
 		try step(nil, nil)
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		var result: [String] = []
 		for node in nodes {
 			result.append(contentsOf: try node.render(context: context))

--- a/Sources/Liquid/Expression.swift
+++ b/Sources/Liquid/Expression.swift
@@ -63,11 +63,11 @@ struct Expression: CustomStringConvertible {
 		self.kind = .lookup(lookup)
 	}
 	
-	func evaluate(context: Context) -> Value {
+	func evaluate(context: RenderContext) -> Value {
 		return evaluate(context: context, data: nil)
 	}
 	
-	private func evaluate(context: Context, data: Value?) -> Value {
+	private func evaluate(context: RenderContext, data: Value?) -> Value {
 		var result: Value?
 		switch kind {
 		case let .lookup(expressions):

--- a/Sources/Liquid/FilterContext.swift
+++ b/Sources/Liquid/FilterContext.swift
@@ -11,7 +11,7 @@ public struct FilterContext {
 	public let encoder: Encoder
 	public let translations: [String: String]?
 	
-	init(context: Context) {
+	init(context: RenderContext) {
 		self.init(encoder: context.encoder, translations: context.translations)
 	}
 	

--- a/Sources/Liquid/Node.swift
+++ b/Sources/Liquid/Node.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol Node {
-	func render(context: Context) throws -> [String]
+	func render(context: RenderContext) throws -> [String]
 }
 
 struct VariableNode: Node {
@@ -18,7 +18,7 @@ struct VariableNode: Node {
 		self.variable = variable
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		return [try variable.evaluate(context: context).liquidString(encoder: context.encoder)]
 	}
 }
@@ -29,7 +29,7 @@ struct StringNode: Node {
 		self.rawValue = rawValue
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		return [rawValue]
 	}
 }

--- a/Sources/Liquid/ParseContext.swift
+++ b/Sources/Liquid/ParseContext.swift
@@ -1,0 +1,12 @@
+//
+//  ParseContext.swift
+//  
+//
+//  Created by Geoffrey Foster on 2019-11-27.
+//
+
+import Foundation
+
+public final class ParseContext {
+	var tags: [String: TagBuilder] = [:]
+}

--- a/Sources/Liquid/Parser.swift
+++ b/Sources/Liquid/Parser.swift
@@ -61,7 +61,3 @@ final class Parser {
 		return tokens[index].value ?? ""
 	}
 }
-
-public class ParseContext {
-	var tags: [String: TagBuilder] = [:]
-}

--- a/Sources/Liquid/RenderContext.swift
+++ b/Sources/Liquid/RenderContext.swift
@@ -1,31 +1,11 @@
 //
-//  Context.swift
+//  RenderContext.swift
 //  
 //
 //  Created by Geoffrey Foster on 2019-09-02.
 //
 
 import Foundation
-
-class Scope {
-	private var values: [String: Value]
-	let mutable: Bool
-	
-	init(mutable: Bool = true, values: [String: Value] = [:]) {
-		self.mutable = mutable
-		self.values = values
-	}
-	
-	subscript(key: String) -> Value? {
-		get {
-			return values[key]
-		}
-		set {
-			guard mutable else { return }
-			values[key] = newValue
-		}
-	}
-}
 
 public struct RegisterKey: Hashable {
 	public let rawValue: String
@@ -35,7 +15,7 @@ public struct RegisterKey: Hashable {
 	}
 }
 
-public final class Context {
+public final class RenderContext {
 	enum Interrupt {
 		case `break`
 		case `continue`
@@ -48,7 +28,7 @@ public final class Context {
 	
 	public let filters: [String: FilterFunc]
 	public let translations: [String: String]?
-	public let tags: [String: TagBuilder]
+	internal let tags: [String: TagBuilder]
 	public let environment: Environment
 	public let encoder: Encoder
 	public let fileSystem: FileSystem

--- a/Sources/Liquid/Scope.swift
+++ b/Sources/Liquid/Scope.swift
@@ -1,0 +1,28 @@
+//
+//  Scope.swift
+//  
+//
+//  Created by Geoffrey Foster on 2019-11-27.
+//
+
+import Foundation
+
+class Scope {
+	private var values: [String: Value]
+	let mutable: Bool
+	
+	init(mutable: Bool = true, values: [String: Value] = [:]) {
+		self.mutable = mutable
+		self.values = values
+	}
+	
+	subscript(key: String) -> Value? {
+		get {
+			return values[key]
+		}
+		set {
+			guard mutable else { return }
+			values[key] = newValue
+		}
+	}
+}

--- a/Sources/Liquid/Tags/Assign.swift
+++ b/Sources/Liquid/Tags/Assign.swift
@@ -21,7 +21,7 @@ struct Assign: Tag {
 	
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		context.setValue(try variable.evaluate(context: context), named: variableName)
 		return []
 	}

--- a/Sources/Liquid/Tags/Break.swift
+++ b/Sources/Liquid/Tags/Break.swift
@@ -11,7 +11,7 @@ struct Break: Tag {
 	init(name: String, markup: String?, context: ParseContext) throws {}
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) -> [String] {
+	func render(context: RenderContext) -> [String] {
 		context.push(interrupt: .break)
 		return []
 	}

--- a/Sources/Liquid/Tags/Capture.swift
+++ b/Sources/Liquid/Tags/Capture.swift
@@ -23,7 +23,7 @@ class Capture: Block, Tag {
 		_ = try super.parse(body: body, tokenizer: tokenizer, context: context)
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		let result = try body.render(context: context)
 		context.setValue(Value(result.joined()), named: variableName)
 		return []

--- a/Sources/Liquid/Tags/Case.swift
+++ b/Sources/Liquid/Tags/Case.swift
@@ -66,7 +66,7 @@ class Case: Block, Tag {
 		conditions.append(CaseCondition(expressions: [], body: BlockBody(), isElse: true))
 	}
 
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		var output: [String] = []
 		let expressionValue = expression.evaluate(context: context)
 		try context.withScope {

--- a/Sources/Liquid/Tags/Comment.swift
+++ b/Sources/Liquid/Tags/Comment.swift
@@ -16,7 +16,7 @@ struct Comment: Tag {
 		fatalError()
 	}
 	
-	func render(context: Context) -> [String] {
+	func render(context: RenderContext) -> [String] {
 		fatalError()
 	}
 }

--- a/Sources/Liquid/Tags/Continue.swift
+++ b/Sources/Liquid/Tags/Continue.swift
@@ -11,7 +11,7 @@ struct Continue: Tag {
 	init(name: String, markup: String?, context: ParseContext) throws {}
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) -> [String] {
+	func render(context: RenderContext) -> [String] {
 		context.push(interrupt: .continue)
 		return []
 	}

--- a/Sources/Liquid/Tags/Cycle.swift
+++ b/Sources/Liquid/Tags/Cycle.swift
@@ -38,7 +38,7 @@ struct Cycle: Tag {
 	
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) -> [String] {
+	func render(context: RenderContext) -> [String] {
 		let registerKey = RegisterKey(name)
 		let lookupKey = nameExpression?.evaluate(context: context).toString() ?? expressions.map { $0.description }.joined(separator: ", ")
 		var registration = (context[registerKey] as? [String: Int]) ?? [:]

--- a/Sources/Liquid/Tags/Decrement.swift
+++ b/Sources/Liquid/Tags/Decrement.swift
@@ -19,7 +19,7 @@ struct Decrement: Tag {
 	
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		let key = Environment.Key(variableName)
 		let value = (context.environment[key]?.toInteger() ?? 0) - 1
 		context.environment[key] = Value(value)

--- a/Sources/Liquid/Tags/For.swift
+++ b/Sources/Liquid/Tags/For.swift
@@ -80,7 +80,7 @@ class For: Block, Tag {
 		}
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		let item: (Int) -> Value
 		var startIndex: Int
 		var endIndex: Int
@@ -159,7 +159,7 @@ private struct ForLoop {
 		return range.isEmpty
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		var output: [String] = []
 		
 		try context.withScope(Scope(mutable: false, values: ["forloop": Value(drop)])) {
@@ -180,7 +180,7 @@ private struct ForLoop {
 		return output
 	}
 	
-	private func renderItemAtIndex(_ index: Int, context: Context) throws -> [String] {
+	private func renderItemAtIndex(_ index: Int, context: RenderContext) throws -> [String] {
 		let value = item(index)
 		let scope = Scope(mutable: false, values: [variableName: value])
 		let results = try context.withScope(scope) {

--- a/Sources/Liquid/Tags/If.swift
+++ b/Sources/Liquid/Tags/If.swift
@@ -68,7 +68,7 @@ final class If: Block, Tag {
 			self.rhs = nil
 		}
 		
-		func evaluate(context: Context) -> Bool {
+		func evaluate(context: RenderContext) -> Bool {
 			var result: Bool
 			if let `operator` = `operator`, let rhs = rhs {
 				let lhsValue = lhs.evaluate(context: context)
@@ -98,7 +98,7 @@ final class If: Block, Tag {
 			self.condition = condition
 		}
 		
-		func evaluate(context: Context) -> Bool {
+		func evaluate(context: RenderContext) -> Bool {
 			guard let condition = condition else { return true }
 			return condition.evaluate(context: context)
 		}
@@ -145,7 +145,7 @@ final class If: Block, Tag {
 		blocks.append(block)
 	}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		if let block = blocks.first {
 			let result = block.evaluate(context: context)
 			if result && !inverted || !result && inverted {

--- a/Sources/Liquid/Tags/Include.swift
+++ b/Sources/Liquid/Tags/Include.swift
@@ -38,7 +38,7 @@ final class Include: Tag {
 	
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		var result: [String] = []
 		let templateName = self.templateName.evaluate(context: context).toString()
 		let template = try loadTemplate(path: templateName, context: context)
@@ -68,7 +68,7 @@ final class Include: Tag {
 		return result
 	}
 	
-	private func loadTemplate(path: String, context: Context) throws -> Template {
+	private func loadTemplate(path: String, context: RenderContext) throws -> Template {
 		guard !path.isEmpty else {
 			throw FileSystemError(reason: "")
 		}

--- a/Sources/Liquid/Tags/Increment.swift
+++ b/Sources/Liquid/Tags/Increment.swift
@@ -19,7 +19,7 @@ struct Increment: Tag {
 	
 	func parse(_ tokenizer: Tokenizer, context: ParseContext) throws {}
 	
-	func render(context: Context) throws -> [String] {
+	func render(context: RenderContext) throws -> [String] {
 		let key = Environment.Key(variableName)
 		let value = (context.environment[key]?.toInteger() ?? 0)
 		context.environment[key] = Value(value + 1)

--- a/Sources/Liquid/Variable.swift
+++ b/Sources/Liquid/Variable.swift
@@ -59,7 +59,7 @@ struct Variable {
 		return (args, kwargs)
 	}
 	
-	func evaluate(context: Context) throws -> Value {
+	func evaluate(context: RenderContext) throws -> Value {
 		var value = expression.evaluate(context: context)
 		for filter in filters {
 			guard let filterFunc = context.filter(named: filter.name) else {

--- a/Tests/LiquidTests/XCTestCase+Extensions.swift
+++ b/Tests/LiquidTests/XCTestCase+Extensions.swift
@@ -12,7 +12,7 @@ func XCTAssertTemplate(_ templateString: String, _ expression2: String, _ values
 	let template = Template(source: templateString, fileSystem: fileSystem)
 	filters?.forEach({ template.registerFilter(name: $0, filter: $1)})
 	
-	XCTAssertNoThrow(try template.parse())
+	XCTAssertNoThrow(try template.parse(), message(), file: file, line: line)
 	do {
 		let result = try template.render(values: values)
 		XCTAssertEqual(result, expression2, message(), file: file, line: line)


### PR DESCRIPTION
* renaming Context to RenderContext
* making tags portion of RenderContext internal only
* moving translations to only being required for render, not for parse

This will enable a parsed Template instance be remain in memory in a cached state, not needing to re-parse it and instead being able to only need to call `render` with the values and translations